### PR TITLE
Fix: Prevent partial directory matching in change detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,9 @@ const main = async () => {
   const pipelines = matches
     .filter((file) => {
       const dirname = path.dirname(path.relative(root, file));
-      return includesBy(relevantChanges, (change) => change.startsWith(dirname));
+      return includesBy(relevantChanges, (change) => {
+        return change === dirname || change.startsWith(dirname + path.sep);
+      });
     })
     .map(buildThenDeploy(registry, shouldDeploy, parsedImageTags));
 


### PR DESCRIPTION
Fixes a bug where directory names that are substrings of others (e.g., shopify_general vs shopify_general_v2) caused false positive builds.

The logic has been updated to strictly enforce directory boundaries (using path.sep) so that changes in a _v2 folder do not trigger builds for the base folder.

Please see the Issue for more details: https://github.com/colpal/actions-batch-docker/issues/30